### PR TITLE
Change version number of ssh-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ jobs:
         ...
         steps:
             - actions/checkout@v1
-            - uses: webfactory/ssh-agent@v0.1
+            - uses: webfactory/ssh-agent@v0.1.1
               with:
                   ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
             - ... other steps


### PR DESCRIPTION
Github Actions failed with `webfactory/ssh-agent@v0.1`.
Works with `webfactory/ssh-agent@v0.1.1`.