### PR TITLE
Support multiple SSH keys

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -1,7 +1,21 @@
 on: [push, pull_request]
 
 jobs:
-    load_key_demo:
+    single_key_demo:
+        strategy:
+            matrix:
+                os: [ubuntu-latest, macOS-latest]
+        runs-on: ${{ matrix.os }}
+        steps:
+            - uses: actions/checkout@v1
+            - name: Setup key
+              uses: ./
+              with:
+                  ssh-private-key: |
+                    ${{ secrets.DEMO_KEY }}
+                    ${{ secrets.DEMO_KEY_2 }}
+
+    multiple_keys_demo:
         strategy:
             matrix:
                 os: [ubuntu-latest, macOS-latest]
@@ -12,8 +26,6 @@ jobs:
               uses: ./
               with:
                   ssh-private-key: ${{ secrets.DEMO_KEY }}
-            - run: |
-                ssh-add -l
-                echo SSH_AUTH_SOCK is at $SSH_AUTH_SOCK
-
+              
+              
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+* Multiple SSH keys can now be provided (#14, closes #7). Thanks to
+  @webknjaz and @bradmartin for support and tests.
+

--- a/dist/index.js
+++ b/dist/index.js
@@ -72,7 +72,11 @@ try {
     core.exportVariable('SSH_AUTH_SOCK', authSock);
 
     console.log("Adding private key to agent");
-    child_process.execSync('ssh-add -', { input: core.getInput('ssh-private-key') });
+    core.getInput('ssh-private-key').split(/(?=-----BEGIN)/).forEach(function(key) {
+        child_process.execSync('ssh-add -', { input: key.trim() + "\n" });
+    });
+    console.log("Keys added:");
+    child_process.execSync('ssh-add -l', { stdio: 'inherit' });
 } catch (error) {
     core.setFailed(error.message);
 }

--- a/index.js
+++ b/index.js
@@ -17,7 +17,11 @@ try {
     core.exportVariable('SSH_AUTH_SOCK', authSock);
 
     console.log("Adding private key to agent");
-    child_process.execSync('ssh-add -', { input: core.getInput('ssh-private-key') });
+    core.getInput('ssh-private-key').split(/(?=-----BEGIN)/).forEach(function(key) {
+        child_process.execSync('ssh-add -', { input: key.trim() + "\n" });
+    });
+    console.log("Keys added:");
+    child_process.execSync('ssh-add -l', { stdio: 'inherit' });
 } catch (error) {
     core.setFailed(error.message);
 }


### PR DESCRIPTION
Multiple SSH keys can be put into the secret value and will be split by the action.

Hopefully this can easily be tried by using `uses: webfactory/ssh-agent@support-multiple-keys` in the workflow definition.

Leave a comment or :+1: here if it works for you.
