### PR TITLE
Remove redundant .trim()

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ try {
     const home = process.env['HOME'];
     const homeSsh = home + '/.ssh';
 
-    const privateKey = core.getInput('ssh-private-key').trim();
+    const privateKey = core.getInput('ssh-private-key');
 
     if (!privateKey) {
         core.setFailed("The ssh-private-key argument is empty. Maybe the secret has not been configured, or you are using a wrong secret name in your workflow file.");


### PR DESCRIPTION
The `core` library already calls `.trim()` on the env value before returning from `getInput`:

https://github.com/actions/toolkit/blob/432a78c48c941e90eedf7911ff0aa271bacad97b/packages/core/src/core.ts#L67-L75