### PR TITLE
Include instructions for adding deploy key

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ specify a passphrase: The key must be usable without reading the passphrase from
 
 To actually grant the SSH key access, you can – on GitHub – use at least two ways:
 
-* [Deploy keys](https://developer.github.com/v3/guides/managing-deploy-keys/#deploy-keys) can be added to individual GitHub repositories. They can give read and/or write access to the particular repository. When pulling a lot of dependencies, however, you'll end up adding the key in many places. Rotating the key probably becomes difficult.
+* [Deploy keys](https://developer.github.com/v3/guides/managing-deploy-keys/#deploy-keys) can be added to individual GitHub repositories. They can give read and/or write access to the particular repository. When pulling a lot of dependencies, however, you'll end up adding the key in many places. Rotating the key probably becomes difficult. The deploy key needs to be added to the private repository that is being fetched as a private dependency.
 
 * A [machine user](https://developer.github.com/v3/guides/managing-deploy-keys/#machine-users) can be used for more fine-grained permissions management and have access to multiple repositories with just one instance of the key being registered. It will, however, count against your number of users on paid GitHub plans.
 


### PR DESCRIPTION
This PR is related to this [issue](https://github.com/webfactory/ssh-agent/issues/31).

It might be obvious to some, but it wasn't obvious for me that the deploy key needed to be added to the private repository that is being fetched by GHA as a private dependency. 

I thought the deploy key needed to be added to the repository that triggers GHA.