### PR TITLE
Updates to support an explicit home directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,8 @@ inputs:
         required: true
     ssh-auth-sock:
         description: 'Where to place the SSH Agent auth socket'
+    home-dir:
+        description: 'Explicit home directory'
 runs:
     using: 'node12'
     main: 'dist/index.js'

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 
 try {
 
-    const home = process.env['HOME'];
+    const home = core.getInput('home-dir') ? core.getInput('home-dir') : process.env['HOME'];
     const homeSsh = home + '/.ssh';
 
     const privateKey = core.getInput('ssh-private-key');


### PR DESCRIPTION
When github mounts container images, they do a number of things to ensure the home directory maps, unfortunately it is not enough and other scripts and programs do not follow their lead. This enables the user to override the environment variable to resolve that issue.