### PR TITLE
Added home equivalent for windows

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -121,7 +121,7 @@ const fs = __webpack_require__(747);
 
 try {
 
-    const home = process.env['HOME'];
+    const home = process.env[(process.platform == 'win32') ? 'USERPROFILE' : 'HOME'];
     const homeSsh = home + '/.ssh';
 
     const privateKey = core.getInput('ssh-private-key');


### PR DESCRIPTION
This PR will add a home equivalent for windows so we can use the ssh-agent from git in windows. 