### PR TITLE
Windows virtual environment: Use SSH binaries from the Git suite

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -1,60 +1,46 @@
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 jobs:
-    single_key_demo:
+    deployment_keys_demo:
         strategy:
+            fail-fast: false
             matrix:
-                os: [ubuntu-latest, macOS-latest, windows-latest]
+                os: [ ubuntu-latest, macOS-latest, windows-latest ]
         runs-on: ${{ matrix.os }}
         steps:
-            - uses: actions/checkout@v2
-            - name: Setup key
-              uses: ./
-              with:
-                  ssh-private-key: |
-                    ${{ secrets.DEMO_KEY }}
-                    ${{ secrets.DEMO_KEY_2 }}
-
-    multiple_keys_demo:
-        strategy:
-            matrix:
-                os: [ubuntu-latest, macOS-latest]
-        runs-on: ${{ matrix.os }}
-        steps:
-            - uses: actions/checkout@v2
-            - name: Setup key
-              uses: ./
-              with:
-                  ssh-private-key: ${{ secrets.DEMO_KEY }}
+            -   uses: actions/checkout@v2
+            -   name: Setup key
+                uses: ./
+                with:
+                    ssh-private-key: |
+                        ${{ secrets.MPDUDE_TEST_1_DEPLOY_KEY }}
+                        ${{ secrets.MPDUDE_TEST_2_DEPLOY_KEY }}
+            -   run: |
+                    git clone https://github.com/mpdude/test-1.git test-1-http
+                    git clone git@github.com:mpdude/test-1.git test-1-git
+                    git clone ssh://git@github.com/mpdude/test-1.git test-1-git-ssh
+                    git clone https://github.com/mpdude/test-2.git test-2-http
+                    git clone git@github.com:mpdude/test-2.git test-2-git
+                    git clone ssh://git@github.com/mpdude/test-2.git test-2-git-ssh
 
     docker_demo:
-        runs-on: ubuntu-latest        
+        runs-on: ubuntu-latest
         container:
             image: ubuntu:latest
         steps:
-            - uses: actions/checkout@v2
-            - run: apt update && apt install -y openssh-client
-            - name: Setup key
-              uses: ./
-              with:
-                  ssh-private-key: |
-                    ${{ secrets.DEMO_KEY }}
-                    ${{ secrets.DEMO_KEY_2 }}
+            -   uses: actions/checkout@v2
+            -   run: apt update && apt install -y openssh-client git
+            -   name: Setup key
+                uses: ./
+                with:
+                    ssh-private-key: |
+                        ${{ secrets.MPDUDE_TEST_1_DEPLOY_KEY }}
+                        ${{ secrets.MPDUDE_TEST_2_DEPLOY_KEY }}
+            -   run: |
+                    git clone https://github.com/mpdude/test-1.git test-1-http
+                    git clone git@github.com:mpdude/test-1.git test-1-git
+                    git clone ssh://git@github.com/mpdude/test-1.git test-1-git-ssh
+                    git clone https://github.com/mpdude/test-2.git test-2-http
+                    git clone git@github.com:mpdude/test-2.git test-2-git
+                    git clone ssh://git@github.com/mpdude/test-2.git test-2-git-ssh
 
-    deployment_keys_demo:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v2
-            - name: Setup key
-              uses: ./
-              with:
-                  ssh-private-key: |
-                    ${{ secrets.MPDUDE_TEST_1_DEPLOY_KEY }}
-                    ${{ secrets.MPDUDE_TEST_2_DEPLOY_KEY }}
-            - run: |
-                git clone https://github.com/mpdude/test-1.git test-1-http
-                git clone git@github.com:mpdude/test-1.git test-1-git
-                git clone ssh://git@github.com/mpdude/test-1.git test-1-git-ssh
-                git clone https://github.com/mpdude/test-2.git test-2-http
-                git clone git@github.com:mpdude/test-2.git test-2-git
-                git clone ssh://git@github.com/mpdude/test-2.git test-2-git-ssh

--- a/cleanup.js
+++ b/cleanup.js
@@ -1,10 +1,12 @@
-const core = require('@actions/core')
-const { execSync } = require('child_process')
+const core = require('@actions/core');
+const { execSync } = require('child_process');
+const { sshAgent } = require('./paths.js');
 
 try {
     // Kill the started SSH agent
-    console.log('Stopping SSH agent')
-    execSync('kill ${SSH_AGENT_PID}', { stdio: 'inherit' })
+    console.log('Stopping SSH agent');
+    execSync(sshAgent, ['-k'], { stdio: 'inherit' });
+
 } catch (error) {
     console.log(error.message);
     console.log('Error stopping the SSH agent, proceeding anyway');

--- a/dist/cleanup.js
+++ b/dist/cleanup.js
@@ -122,13 +122,15 @@ module.exports = require("child_process");
 /***/ 175:
 /***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
 
-const core = __webpack_require__(470)
-const { execSync } = __webpack_require__(129)
+const core = __webpack_require__(470);
+const { execSync } = __webpack_require__(129);
+const { sshAgent } = __webpack_require__(972);
 
 try {
     // Kill the started SSH agent
-    console.log('Stopping SSH agent')
-    execSync('kill ${SSH_AGENT_PID}', { stdio: 'inherit' })
+    console.log('Stopping SSH agent');
+    execSync(sshAgent, ['-k'], { stdio: 'inherit' });
+
 } catch (error) {
     console.log(error.message);
     console.log('Error stopping the SSH agent, proceeding anyway');
@@ -479,6 +481,31 @@ module.exports = require("path");
 /***/ (function(module) {
 
 module.exports = require("fs");
+
+/***/ }),
+
+/***/ 972:
+/***/ (function(module, __unusedexports, __webpack_require__) {
+
+const os = __webpack_require__(87);
+
+module.exports = (process.env['OS'] != 'Windows_NT') ? {
+
+    // Use getent() system call, since this is what ssh does; makes a difference in Docker-based
+    // Action runs, where $HOME is different from the pwent
+    home: os.userInfo().homedir,
+    sshAgent: 'ssh-agent',
+    sshAdd: 'ssh-add'
+
+} : {
+
+    home: os.homedir(),
+    sshAgent: 'c://progra~1//git//usr//bin//ssh-agent.exe',
+    sshAdd: 'c://progra~1//git//usr//bin//ssh-add.exe'
+
+};
+
+
 
 /***/ })
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -118,8 +118,8 @@ exports.issueCommand = issueCommand;
 const core = __webpack_require__(470);
 const child_process = __webpack_require__(129);
 const fs = __webpack_require__(747);
-const os = __webpack_require__(87);
 const crypto = __webpack_require__(417);
+const { home, sshAgent, sshAdd } = __webpack_require__(972);
 
 try {
     const privateKey = core.getInput('ssh-private-key');
@@ -129,22 +129,6 @@ try {
 
         return;
     }
-
-    const { home, sshAgent, sshAdd } = (process.env['OS'] != 'Windows_NT') ? {
-
-              // Use getent() system call, since this is what ssh does; makes a difference in Docker-based
-              // Action runs, where $HOME is different from the pwent
-              home: os.userInfo().homedir,
-              sshAgent: 'ssh-agent',
-              sshAdd: 'ssh-add'
-
-          } : {
-
-              home: os.homedir(),
-              sshAgent: 'c://progra~1//git//usr//bin//ssh-agent.exe',
-              sshAdd: 'c://progra~1//git//usr//bin//ssh-add.exe'
-
-          };
 
     const homeSsh = home + '/.ssh';
 
@@ -571,6 +555,31 @@ module.exports = require("path");
 /***/ (function(module) {
 
 module.exports = require("fs");
+
+/***/ }),
+
+/***/ 972:
+/***/ (function(module, __unusedexports, __webpack_require__) {
+
+const os = __webpack_require__(87);
+
+module.exports = (process.env['OS'] != 'Windows_NT') ? {
+
+    // Use getent() system call, since this is what ssh does; makes a difference in Docker-based
+    // Action runs, where $HOME is different from the pwent
+    home: os.userInfo().homedir,
+    sshAgent: 'ssh-agent',
+    sshAdd: 'ssh-add'
+
+} : {
+
+    home: os.homedir(),
+    sshAgent: 'c://progra~1//git//usr//bin//ssh-agent.exe',
+    sshAdd: 'c://progra~1//git//usr//bin//ssh-add.exe'
+
+};
+
+
 
 /***/ })
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -130,77 +130,82 @@ try {
         return;
     }
 
-    var home;
+    const { home, sshAgent, sshAdd } = (process.env['OS'] != 'Windows_NT') ? {
 
-    if (process.env['OS'] == 'Windows_NT') {
-        console.log('Preparing ssh-agent service on Windows');
-        child_process.execSync('sc config ssh-agent start=demand', { stdio: 'inherit' });
+              // Use getent() system call, since this is what ssh does; makes a difference in Docker-based
+              // Action runs, where $HOME is different from the pwent
+              home: os.userInfo().homedir,
+              sshAgent: 'ssh-agent',
+              sshAdd: 'ssh-add'
 
-        home = os.homedir();
-    } else {
-        // Use getent() system call, since this is what ssh does; makes a difference in Docker-based
-        // Action runs, where $HOME is different from the pwent
-        var { homedir: home } = os.userInfo();
-    }
+          } : {
+
+              home: os.homedir(),
+              sshAgent: 'c://progra~1//git//usr//bin//ssh-agent.exe',
+              sshAdd: 'c://progra~1//git//usr//bin//ssh-add.exe'
+
+          };
 
     const homeSsh = home + '/.ssh';
 
     console.log(`Adding GitHub.com keys to ${homeSsh}/known_hosts`);
+
     fs.mkdirSync(homeSsh, { recursive: true });
     fs.appendFileSync(`${homeSsh}/known_hosts`, '\ngithub.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==\n');
     fs.appendFileSync(`${homeSsh}/known_hosts`, '\ngithub.com ssh-dss AAAAB3NzaC1kc3MAAACBANGFW2P9xlGU3zWrymJgI/lKo//ZW2WfVtmbsUZJ5uyKArtlQOT2+WRhcg4979aFxgKdcsqAYW3/LS1T2km3jYW/vr4Uzn+dXWODVk5VlUiZ1HFOHf6s6ITcZvjvdbp6ZbpM+DuJT7Bw+h5Fx8Qt8I16oCZYmAPJRtu46o9C2zk1AAAAFQC4gdFGcSbp5Gr0Wd5Ay/jtcldMewAAAIATTgn4sY4Nem/FQE+XJlyUQptPWMem5fwOcWtSXiTKaaN0lkk2p2snz+EJvAGXGq9dTSWHyLJSM2W6ZdQDqWJ1k+cL8CARAqL+UMwF84CR0m3hj+wtVGD/J4G5kW2DBAf4/bqzP4469lT+dF2FRQ2L9JKXrCWcnhMtJUvua8dvnwAAAIB6C4nQfAA7x8oLta6tT+oCk2WQcydNsyugE8vLrHlogoWEicla6cWPk7oXSspbzUcfkjN3Qa6e74PhRkc7JdSdAlFzU3m7LMkXo1MHgkqNX8glxWNVqBSc0YRdbFdTkL0C6gtpklilhvuHQCdbgB3LBAikcRkDp+FCVkUgPC/7Rw==\n');
 
     console.log("Starting ssh-agent");
+
     const authSock = core.getInput('ssh-auth-sock');
-    let sshAgentOutput = ''
-    if (authSock && authSock.length > 0) {
-        sshAgentOutput = child_process.execFileSync('ssh-agent', ['-a', authSock]);
-    } else {
-        sshAgentOutput = child_process.execFileSync('ssh-agent')
-    }
+    const sshAgentArgs = (authSock && authSock.length > 0) ? ['-a', authSock] : [];
 
     // Extract auth socket path and agent pid and set them as job variables
-    const lines = sshAgentOutput.toString().split("\n")
-    for (const lineNumber in lines) {
-        const matches = /^(SSH_AUTH_SOCK|SSH_AGENT_PID)=(.*); export \1/.exec(lines[lineNumber])
-        if (matches && matches.length > 0) {
-            core.exportVariable(matches[1], matches[2])
-        }
-    }
+    child_process.execFileSync(sshAgent, sshAgentArgs).toString().split("\n").forEach(function(line) {
+        const matches = /^(SSH_AUTH_SOCK|SSH_AGENT_PID)=(.*); export \1/.exec(line);
 
-    console.log("Adding private key to agent");
-    privateKey.split(/(?=-----BEGIN)/).forEach(function(key) {
-        child_process.execSync('ssh-add -', { input: key.trim() + "\n" });
+        if (matches && matches.length > 0) {
+            // This will also set process.env accordingly, so changes take effect for this script
+            core.exportVariable(matches[1], matches[2])
+            console.log(`${matches[1]}=${matches[2]}`);
+        }
     });
 
-    console.log("Keys added:");
-    child_process.execSync('ssh-add -l', { stdio: 'inherit' });
+    console.log("Adding private key(s) to agent");
 
-    child_process.execFileSync('ssh-add', ['-L']).toString().split(/\r?\n/).forEach(function(key) {
-        let parts = key.match(/\bgithub.com[:/](.*)(?:\.git)?\b/);
+    privateKey.split(/(?=-----BEGIN)/).forEach(function(key) {
+        child_process.execFileSync(sshAdd, ['-'], { input: key.trim() + "\n" });
+    });
 
-        if (parts == null) {
+    console.log("Key(s) added:");
+
+    child_process.execFileSync(sshAdd, ['-l'], { stdio: 'inherit' });
+
+    console.log('Configuring deployment key(s)');
+
+    child_process.execFileSync(sshAdd, ['-L']).toString().split(/\r?\n/).forEach(function(key) {
+        const parts = key.match(/\bgithub\.com[:/]([_.a-z0-9-]+\/[_.a-z0-9-]+)/);
+
+        if (!parts) {
             return;
         }
 
-        let ownerAndRepo = parts[1];
-        let sha256 = crypto.createHash('sha256').update(key).digest('hex');
+        const sha256 = crypto.createHash('sha256').update(key).digest('hex');
+        const ownerAndRepo = parts[1].replace(/\.git$/, '');
 
-        fs.writeFileSync(`${homeSsh}/${sha256}`, key + "\n", { mode: '600' });
+        fs.writeFileSync(`${homeSsh}/key-${sha256}`, key + "\n", { mode: '600' });
 
-        child_process.execSync(`git config --global --replace-all url."git@${sha256}:${ownerAndRepo}".insteadOf "https://github.com/${ownerAndRepo}"`);
-        child_process.execSync(`git config --global --add url."git@${sha256}:${ownerAndRepo}".insteadOf "git@github.com:${ownerAndRepo}"`);
-        child_process.execSync(`git config --global --add url."git@${sha256}:${ownerAndRepo}".insteadOf "ssh://git@github.com/${ownerAndRepo}"`);
+        child_process.execSync(`git config --global --replace-all url."git@key-${sha256}.github.com:${ownerAndRepo}".insteadOf "https://github.com/${ownerAndRepo}"`);
+        child_process.execSync(`git config --global --add url."git@key-${sha256}.github.com:${ownerAndRepo}".insteadOf "git@github.com:${ownerAndRepo}"`);
+        child_process.execSync(`git config --global --add url."git@key-${sha256}.github.com:${ownerAndRepo}".insteadOf "ssh://git@github.com/${ownerAndRepo}"`);
 
-        let sshConfig = `\nHost ${sha256}\n`
+        const sshConfig = `\nHost key-${sha256}.github.com\n`
                               + `    HostName github.com\n`
-                              + `    User git\n`
-                              + `    IdentityFile ${homeSsh}/${sha256}\n`
+                              + `    IdentityFile ${homeSsh}/key-${sha256}\n`
                               + `    IdentitiesOnly yes\n`;
 
         fs.appendFileSync(`${homeSsh}/config`, sshConfig);
 
-        console.log(`Added deploy-key mapping: Use key "${key}" for GitHub repository ${ownerAndRepo}`);
+        console.log(`Added deploy-key mapping: Use identity '${homeSsh}/key-${sha256}' for GitHub repository ${ownerAndRepo}`);
     });
 
 } catch (error) {

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 const core = require('@actions/core');
 const child_process = require('child_process');
 const fs = require('fs');
-const os = require('os');
 const crypto = require('crypto');
+const { home, sshAgent, sshAdd } = require('./paths.js');
 
 try {
     const privateKey = core.getInput('ssh-private-key');
@@ -12,22 +12,6 @@ try {
 
         return;
     }
-
-    const { home, sshAgent, sshAdd } = (process.env['OS'] != 'Windows_NT') ? {
-
-              // Use getent() system call, since this is what ssh does; makes a difference in Docker-based
-              // Action runs, where $HOME is different from the pwent
-              home: os.userInfo().homedir,
-              sshAgent: 'ssh-agent',
-              sshAdd: 'ssh-add'
-
-          } : {
-
-              home: os.homedir(),
-              sshAgent: 'c://progra~1//git//usr//bin//ssh-agent.exe',
-              sshAdd: 'c://progra~1//git//usr//bin//ssh-add.exe'
-
-          };
 
     const homeSsh = home + '/.ssh';
 

--- a/index.js
+++ b/index.js
@@ -13,77 +13,82 @@ try {
         return;
     }
 
-    var home;
+    const { home, sshAgent, sshAdd } = (process.env['OS'] != 'Windows_NT') ? {
 
-    if (process.env['OS'] == 'Windows_NT') {
-        console.log('Preparing ssh-agent service on Windows');
-        child_process.execSync('sc config ssh-agent start=demand', { stdio: 'inherit' });
+              // Use getent() system call, since this is what ssh does; makes a difference in Docker-based
+              // Action runs, where $HOME is different from the pwent
+              home: os.userInfo().homedir,
+              sshAgent: 'ssh-agent',
+              sshAdd: 'ssh-add'
 
-        home = os.homedir();
-    } else {
-        // Use getent() system call, since this is what ssh does; makes a difference in Docker-based
-        // Action runs, where $HOME is different from the pwent
-        var { homedir: home } = os.userInfo();
-    }
+          } : {
+
+              home: os.homedir(),
+              sshAgent: 'c://progra~1//git//usr//bin//ssh-agent.exe',
+              sshAdd: 'c://progra~1//git//usr//bin//ssh-add.exe'
+
+          };
 
     const homeSsh = home + '/.ssh';
 
     console.log(`Adding GitHub.com keys to ${homeSsh}/known_hosts`);
+
     fs.mkdirSync(homeSsh, { recursive: true });
     fs.appendFileSync(`${homeSsh}/known_hosts`, '\ngithub.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==\n');
     fs.appendFileSync(`${homeSsh}/known_hosts`, '\ngithub.com ssh-dss AAAAB3NzaC1kc3MAAACBANGFW2P9xlGU3zWrymJgI/lKo//ZW2WfVtmbsUZJ5uyKArtlQOT2+WRhcg4979aFxgKdcsqAYW3/LS1T2km3jYW/vr4Uzn+dXWODVk5VlUiZ1HFOHf6s6ITcZvjvdbp6ZbpM+DuJT7Bw+h5Fx8Qt8I16oCZYmAPJRtu46o9C2zk1AAAAFQC4gdFGcSbp5Gr0Wd5Ay/jtcldMewAAAIATTgn4sY4Nem/FQE+XJlyUQptPWMem5fwOcWtSXiTKaaN0lkk2p2snz+EJvAGXGq9dTSWHyLJSM2W6ZdQDqWJ1k+cL8CARAqL+UMwF84CR0m3hj+wtVGD/J4G5kW2DBAf4/bqzP4469lT+dF2FRQ2L9JKXrCWcnhMtJUvua8dvnwAAAIB6C4nQfAA7x8oLta6tT+oCk2WQcydNsyugE8vLrHlogoWEicla6cWPk7oXSspbzUcfkjN3Qa6e74PhRkc7JdSdAlFzU3m7LMkXo1MHgkqNX8glxWNVqBSc0YRdbFdTkL0C6gtpklilhvuHQCdbgB3LBAikcRkDp+FCVkUgPC/7Rw==\n');
 
     console.log("Starting ssh-agent");
+
     const authSock = core.getInput('ssh-auth-sock');
-    let sshAgentOutput = ''
-    if (authSock && authSock.length > 0) {
-        sshAgentOutput = child_process.execFileSync('ssh-agent', ['-a', authSock]);
-    } else {
-        sshAgentOutput = child_process.execFileSync('ssh-agent')
-    }
+    const sshAgentArgs = (authSock && authSock.length > 0) ? ['-a', authSock] : [];
 
     // Extract auth socket path and agent pid and set them as job variables
-    const lines = sshAgentOutput.toString().split("\n")
-    for (const lineNumber in lines) {
-        const matches = /^(SSH_AUTH_SOCK|SSH_AGENT_PID)=(.*); export \1/.exec(lines[lineNumber])
-        if (matches && matches.length > 0) {
-            core.exportVariable(matches[1], matches[2])
-        }
-    }
+    child_process.execFileSync(sshAgent, sshAgentArgs).toString().split("\n").forEach(function(line) {
+        const matches = /^(SSH_AUTH_SOCK|SSH_AGENT_PID)=(.*); export \1/.exec(line);
 
-    console.log("Adding private key to agent");
-    privateKey.split(/(?=-----BEGIN)/).forEach(function(key) {
-        child_process.execSync('ssh-add -', { input: key.trim() + "\n" });
+        if (matches && matches.length > 0) {
+            // This will also set process.env accordingly, so changes take effect for this script
+            core.exportVariable(matches[1], matches[2])
+            console.log(`${matches[1]}=${matches[2]}`);
+        }
     });
 
-    console.log("Keys added:");
-    child_process.execSync('ssh-add -l', { stdio: 'inherit' });
+    console.log("Adding private key(s) to agent");
 
-    child_process.execFileSync('ssh-add', ['-L']).toString().split(/\r?\n/).forEach(function(key) {
-        let parts = key.match(/\bgithub.com[:/](.*)(?:\.git)?\b/);
+    privateKey.split(/(?=-----BEGIN)/).forEach(function(key) {
+        child_process.execFileSync(sshAdd, ['-'], { input: key.trim() + "\n" });
+    });
 
-        if (parts == null) {
+    console.log("Key(s) added:");
+
+    child_process.execFileSync(sshAdd, ['-l'], { stdio: 'inherit' });
+
+    console.log('Configuring deployment key(s)');
+
+    child_process.execFileSync(sshAdd, ['-L']).toString().split(/\r?\n/).forEach(function(key) {
+        const parts = key.match(/\bgithub\.com[:/]([_.a-z0-9-]+\/[_.a-z0-9-]+)/);
+
+        if (!parts) {
             return;
         }
 
-        let ownerAndRepo = parts[1];
-        let sha256 = crypto.createHash('sha256').update(key).digest('hex');
+        const sha256 = crypto.createHash('sha256').update(key).digest('hex');
+        const ownerAndRepo = parts[1].replace(/\.git$/, '');
 
-        fs.writeFileSync(`${homeSsh}/${sha256}`, key + "\n", { mode: '600' });
+        fs.writeFileSync(`${homeSsh}/key-${sha256}`, key + "\n", { mode: '600' });
 
-        child_process.execSync(`git config --global --replace-all url."git@${sha256}:${ownerAndRepo}".insteadOf "https://github.com/${ownerAndRepo}"`);
-        child_process.execSync(`git config --global --add url."git@${sha256}:${ownerAndRepo}".insteadOf "git@github.com:${ownerAndRepo}"`);
-        child_process.execSync(`git config --global --add url."git@${sha256}:${ownerAndRepo}".insteadOf "ssh://git@github.com/${ownerAndRepo}"`);
+        child_process.execSync(`git config --global --replace-all url."git@key-${sha256}.github.com:${ownerAndRepo}".insteadOf "https://github.com/${ownerAndRepo}"`);
+        child_process.execSync(`git config --global --add url."git@key-${sha256}.github.com:${ownerAndRepo}".insteadOf "git@github.com:${ownerAndRepo}"`);
+        child_process.execSync(`git config --global --add url."git@key-${sha256}.github.com:${ownerAndRepo}".insteadOf "ssh://git@github.com/${ownerAndRepo}"`);
 
-        let sshConfig = `\nHost ${sha256}\n`
+        const sshConfig = `\nHost key-${sha256}.github.com\n`
                               + `    HostName github.com\n`
-                              + `    User git\n`
-                              + `    IdentityFile ${homeSsh}/${sha256}\n`
+                              + `    IdentityFile ${homeSsh}/key-${sha256}\n`
                               + `    IdentitiesOnly yes\n`;
 
         fs.appendFileSync(`${homeSsh}/config`, sshConfig);
 
-        console.log(`Added deploy-key mapping: Use key "${key}" for GitHub repository ${ownerAndRepo}`);
+        console.log(`Added deploy-key mapping: Use identity '${homeSsh}/key-${sha256}' for GitHub repository ${ownerAndRepo}`);
     });
 
 } catch (error) {

--- a/paths.js
+++ b/paths.js
@@ -1,0 +1,18 @@
+const os = require('os');
+
+module.exports = (process.env['OS'] != 'Windows_NT') ? {
+
+    // Use getent() system call, since this is what ssh does; makes a difference in Docker-based
+    // Action runs, where $HOME is different from the pwent
+    home: os.userInfo().homedir,
+    sshAgent: 'ssh-agent',
+    sshAdd: 'ssh-add'
+
+} : {
+
+    home: os.homedir(),
+    sshAgent: 'c://progra~1//git//usr//bin//ssh-agent.exe',
+    sshAdd: 'c://progra~1//git//usr//bin//ssh-add.exe'
+
+};
+


### PR DESCRIPTION
This hopefully fixes Windows-based builds, including issue #62.

It was a much bigger rabbit hole than initially expected, and took quite some time and experimentation. It turns out there are two versions of the `ssh` and related binaries available in the Windows virtual environment.

```
C:\>C:\Windows\System32\OpenSSH\ssh.exe -v xx
OpenSSH_for_Windows_7.7p1, LibreSSL 2.6.5

C:\>C:\"Program Files"\Git\usr\bin\ssh.exe -v xx
OpenSSH_8.4p1, OpenSSL 1.1.1i  8 Dec 2020
```

Things seem to work when using the `ssh-agent` and `ssh-add` binaries provided as part of the Git installation, but not with the native Windows ones.

As of writing, simple `git clone ...` operations given in a GHA workflow file will use the `ssh` client from the Git suite, without further configuration. I don't know if this might change in the future; https://github.com/git-for-windows/git/issues/2944 is about possibly changing this.

As a reminder to myself, just in case we need to get back to this sometime:

* Not really clear what the source repos for the version [provided by Windows](https://docs.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse) are. Candidates are https://github.com/PowerShell/OpenSSH-Portable or https://github.com/PowerShell/Win32-OpenSSH.
* In the Windows version, `IdentityFile` cannot point to a file containing the _public_ key part, it complains about the "invalid format".
* We could write _private_ keys to these files and encrypt them (`ssh-keygen -p ...`), but that would need to happen _before_ loading into the agent, otherwise it does not recognize keys later on
* To load encrypted keys, the passphrase cannot be provided on `stdin` to `ssh-add`, but instead the `DISPLAY` env var has to be set to some dummy value. That will make `ssh-add` fork the program from `SSH_ASKPASS`, where we can place a [simple program](https://github.com/webfactory/ssh-agent/blob/2d8d48e56abeab8166c5fdf12ee3fed6007cc85f/askpass.c) to pass the value of another env var back as the passphrase.
* Windows `ssh` client seems to _ignore_ keys from the agent when `IdentitiesOnly=yes`, see https://github.com/PowerShell/Win32-OpenSSH/issues/1550
* Things _might_ work with `IdentitiesOnly=false` _on Windows_, _if_ the specified keys are tried _before_ the other ones.
* A few times, I stumbled across `ssh` complaining that `/dev/tty` is not a file – seems to be an issue in how that SSH client tries to detect a terminal (https://github.com/PowerShell/openssh-portable/pull/447)

I don't know if "mixing" the SSH client and/or other binaries (the agent) from Windows and Git has any other side effects or implications. 

🤞🏻