### PR TITLE
#68 Option 1: Add capital letters as acceptable characters in key matching

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ try {
     console.log('Configuring deployment key(s)');
 
     child_process.execFileSync(sshAdd, ['-L']).toString().split(/\r?\n/).forEach(function(key) {
-        const parts = key.match(/\bgithub\.com[:/]([_.a-z0-9-]+\/[_.a-z0-9-]+)/);
+        const parts = key.match(/\bgithub\.com[:/]([_.a-zA-Z0-9-]+\/[_.a-zA-Z0-9-]+)/);
 
         if (!parts) {
             return;


### PR DESCRIPTION
Resolves #68 by allowing capital letters as part of the regex. 

NOTE: Only option 1 or option 2 should be necessary to merge here.