### PR TITLE
Run cleanup (post) step also on failure

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,7 @@ runs:
     using: 'node12'
     main: 'dist/index.js'
     post: 'dist/cleanup.js'
+    post-if: 'always()'
 branding:
     icon: loader
     color: 'yellow'


### PR DESCRIPTION
According to https://github.com/actions/runner/issues/987, this should run the post step (cleanup.js) also when a workflow fails.

Probably most important on self-hosted runners that are not ephemeral, to terminate SSH agents from failed jobs as well.
