### PR TITLE
Use execFileSync to clean up

### DIFF
--- a/cleanup.js
+++ b/cleanup.js
@@ -1,12 +1,11 @@
 const core = require('@actions/core');
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 const { sshAgent } = require('./paths.js');
 
 try {
     // Kill the started SSH agent
     console.log('Stopping SSH agent');
-    execSync(sshAgent, ['-k'], { stdio: 'inherit' });
-
+    execFileSync(sshAgent, ['-k'], { stdio: 'inherit' });
 } catch (error) {
     console.log(error.message);
     console.log('Error stopping the SSH agent, proceeding anyway');

--- a/dist/cleanup.js
+++ b/dist/cleanup.js
@@ -123,14 +123,13 @@ module.exports = require("child_process");
 /***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
 
 const core = __webpack_require__(470);
-const { execSync } = __webpack_require__(129);
+const { execFileSync } = __webpack_require__(129);
 const { sshAgent } = __webpack_require__(972);
 
 try {
     // Kill the started SSH agent
     console.log('Stopping SSH agent');
-    execSync(sshAgent, ['-k'], { stdio: 'inherit' });
-
+    execFileSync(sshAgent, ['-k'], { stdio: 'inherit' });
 } catch (error) {
     console.log(error.message);
     console.log('Error stopping the SSH agent, proceeding anyway');


### PR DESCRIPTION
I noticed that on my self-hosted runner `ssh-agent` processes accumulated despite the action's cleanup. Also nothing was printed, and `ssh-add -k` executed locally prints a message.

Original `execSync` call took first argument as the full command to run and it just started a second ssh-agent. `['-k']` argument was treated as options, it didn't have `stdio` set, so stdio was piped and returned (and ignored), which explains no output.

Before:
![image](https://user-images.githubusercontent.com/52241383/121690306-fa33d100-cac5-11eb-88cb-2d7c317734c9.png)

After:
![image](https://user-images.githubusercontent.com/52241383/121690364-0cae0a80-cac6-11eb-8866-a96a2926eb97.png)
