### PR TITLE
Fix a potential security leak with ssh private keys and ignore empty keys

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -166,11 +166,17 @@ try {
 
     console.log('Configuring deployment key(s)');
 
-    child_process.execFileSync(sshAdd, ['-L']).toString().split(/\r?\n/).forEach(function(key) {
+    child_process.execFileSync(sshAdd, ['-L']).toString().split(/\r?\n/).forEach(function(key, index) {
+        if (!key) {
+            console.log(`Ignoring empty key at position ${index}.`);
+
+            return;
+        }
+
         const parts = key.match(/\bgithub\.com[:/]([_.a-z0-9-]+\/[_.a-z0-9-]+)/i);
 
         if (!parts) {
-            console.log(`Comment for key '${key}' does not match GitHub URL pattern. Not treating it as a GitHub deploy key.`);
+            console.log(`Comment for key at position ${index} does not match GitHub URL pattern. Not treating it as a GitHub deploy key.`);
 
             return;
         }

--- a/index.js
+++ b/index.js
@@ -49,11 +49,17 @@ try {
 
     console.log('Configuring deployment key(s)');
 
-    child_process.execFileSync(sshAdd, ['-L']).toString().split(/\r?\n/).forEach(function(key) {
+    child_process.execFileSync(sshAdd, ['-L']).toString().split(/\r?\n/).forEach(function(key, index) {
+        if (!key) {
+            console.log(`Ignoring empty key at position ${index}.`);
+
+            return;
+        }
+
         const parts = key.match(/\bgithub\.com[:/]([_.a-z0-9-]+\/[_.a-z0-9-]+)/i);
 
         if (!parts) {
-            console.log(`Comment for key '${key}' does not match GitHub URL pattern. Not treating it as a GitHub deploy key.`);
+            console.log(`Comment for key at position ${index} does not match GitHub URL pattern. Not treating it as a GitHub deploy key.`);
 
             return;
         }


### PR DESCRIPTION
This pull request fix a potential security leak in workflow logs when the private key is not a GitHub deployment key.

Instead of writing the entire private key in logs, the zero based position of the key in the provided list is now outputted.

At the same time, I tweaked the flow to ignore empty keys before verifying if it's a GitHub deployment key!