### PR TITLE
Added clarification to key distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ GitHub Actions only have access to the repository they run for. So, in order to 
 
 ## Usage
 
-1. Generate a new SSH key (if you will be pulling from multiple private repositories, please see the comments below in the Github Deploy Keys Section) with sufficient access privileges. For security reasons, don't use your personal SSH key but set up a dedicated one for use in GitHub Actions. See below for a few hints if you are unsure about this step.
+1. Generate a new SSH key with sufficient access privileges. For security reasons, don't use your personal SSH key but set up a dedicated one for use in GitHub Actions. See below for a few hints if you are unsure about this step.
 2. Make sure you don't have a passphrase set on the private key.
 3. Add the public SSH key to the private repository you are pulling from during the Github Action.
 3. Add the private SSH key to the repository triggering the Github Action: 

--- a/README.md
+++ b/README.md
@@ -20,10 +20,13 @@ GitHub Actions only have access to the repository they run for. So, in order to 
 
 ## Usage
 
-1. Create an SSH key with sufficient access privileges. For security reasons, don't use your personal SSH key but set up a dedicated one for use in GitHub Actions. See below for a few hints if you are unsure about this step.
+1. Generate a new SSH key (if you will be pulling from multiple private repositories, please see the comments below in the Github Deploy Keys Section) with sufficient access privileges. For security reasons, don't use your personal SSH key but set up a dedicated one for use in GitHub Actions. See below for a few hints if you are unsure about this step.
 2. Make sure you don't have a passphrase set on the private key.
-3. In your repository, go to the *Settings > Secrets* menu and create a new secret. In this example, we'll call it `SSH_PRIVATE_KEY`. Put the contents of the *private* SSH key file into the contents field. <br>
-  This key should start with `-----BEGIN ... PRIVATE KEY-----`, consist of many lines and ends with `-----END ... PRIVATE KEY-----`. 
+3. Add the public SSH key to the private repository you are pulling from during the Github Action.
+3. Add the private SSH key to the repository triggering the Github Action: 
+    * In your repository, go to the *Settings > Secrets* menu and create a new secret. In this example, we'll call it `SSH_PRIVATE_KEY`. 
+    * Put the contents of the *private* SSH key file into the contents field. <br>
+    * This key should start with `-----BEGIN ... PRIVATE KEY-----`, consist of many lines and ends with `-----END ... PRIVATE KEY-----`. 
 4. In your workflow definition file, add the following step. Preferably this would be rather on top, near the `actions/checkout@v2` line.
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ GitHub Actions only have access to the repository they run for. So, in order to 
 
 1. Generate a new SSH key with sufficient access privileges. For security reasons, don't use your personal SSH key but set up a dedicated one for use in GitHub Actions. See below for a few hints if you are unsure about this step.
 2. Make sure you don't have a passphrase set on the private key.
-3. Add the public SSH key to the private repository you are pulling from during the Github Action.
+3. Add the public SSH key to the private repository you are pulling from during the Github Action as a 'Deploy Key'.
 4. Add the private SSH key to the repository triggering the Github Action: 
     * In your repository, go to the *Settings > Secrets* menu and create a new secret. In this example, we'll call it `SSH_PRIVATE_KEY`. 
     * Put the contents of the *private* SSH key file into the contents field. <br>

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ GitHub Actions only have access to the repository they run for. So, in order to 
 1. Generate a new SSH key with sufficient access privileges. For security reasons, don't use your personal SSH key but set up a dedicated one for use in GitHub Actions. See below for a few hints if you are unsure about this step.
 2. Make sure you don't have a passphrase set on the private key.
 3. Add the public SSH key to the private repository you are pulling from during the Github Action.
-3. Add the private SSH key to the repository triggering the Github Action: 
+4. Add the private SSH key to the repository triggering the Github Action: 
     * In your repository, go to the *Settings > Secrets* menu and create a new secret. In this example, we'll call it `SSH_PRIVATE_KEY`. 
     * Put the contents of the *private* SSH key file into the contents field. <br>
     * This key should start with `-----BEGIN ... PRIVATE KEY-----`, consist of many lines and ends with `-----END ... PRIVATE KEY-----`. 
-4. In your workflow definition file, add the following step. Preferably this would be rather on top, near the `actions/checkout@v2` line.
+5. In your workflow definition file, add the following step. Preferably this would be rather on top, near the `actions/checkout@v2` line.
 
 ```yaml
 # .github/workflows/my-workflow.yml


### PR DESCRIPTION
**Added clarification to key distributions.**

Original wording just said "in your repository" - this could have referred to the one triggering the Github action or the one being pulled from. A few extra words can clear this ambiguity up and make the documentation non-ambiguous.