### PR TITLE
Update from node12 to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     ssh-auth-sock:
         description: 'Where to place the SSH Agent auth socket'
 runs:
-    using: 'node12'
+    using: 'node16'
     main: 'dist/index.js'
     post: 'dist/cleanup.js'
     post-if: 'always()'


### PR DESCRIPTION
Hi,

Thanks for such a useful Action!

Can you consider updating the version of `Node` as per GitHub:
* https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
* https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-javascript-actions

I have tested successfully in private repos that were using `webfactory/ssh-agent@v0.5.4` version.
Thanks!