### PR TITLE
Avoid nonsensical log message

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -371,7 +371,7 @@ try {
 
     console.log('Configuring deployment key(s)');
 
-    child_process.execFileSync(sshAddCmd, ['-L']).toString().split(/\r?\n/).forEach(function(key) {
+    child_process.execFileSync(sshAddCmd, ['-L']).toString().trim().split(/\r?\n/).forEach(function(key) {
         const parts = key.match(/\bgithub\.com[:/]([_.a-z0-9-]+\/[_.a-z0-9-]+)/i);
 
         if (!parts) {

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ try {
 
     console.log('Configuring deployment key(s)');
 
-    child_process.execFileSync(sshAddCmd, ['-L']).toString().split(/\r?\n/).forEach(function(key) {
+    child_process.execFileSync(sshAddCmd, ['-L']).toString().trim().split(/\r?\n/).forEach(function(key) {
         const parts = key.match(/\bgithub\.com[:/]([_.a-z0-9-]+\/[_.a-z0-9-]+)/i);
 
         if (!parts) {


### PR DESCRIPTION
This change avoids the

`Comment for (public) key '' does not match GitHub URL pattern. Not treating it as a GitHub deploy key.`

log message that was caused by inappropriate parsing of `ssh-add -L` output and confused a lot of users already.
