### PR TITLE
Fix path to `git` binary on Windows runners

### DIFF
--- a/dist/cleanup.js
+++ b/dist/cleanup.js
@@ -2835,7 +2835,7 @@ module.exports = (process.env['OS'] != 'Windows_NT') ? {
     homePath: os.homedir(),
     sshAgentCmd: 'c://progra~1//git//usr//bin//ssh-agent.exe',
     sshAddCmd: 'c://progra~1//git//usr//bin//ssh-add.exe',
-    gitCmd: 'c://progra~1//git//usr//bin//git.exe'
+    gitCmd: 'c://progra~1//git//bin//git.exe'
 };
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -2914,7 +2914,7 @@ module.exports = (process.env['OS'] != 'Windows_NT') ? {
     homePath: os.homedir(),
     sshAgentCmd: 'c://progra~1//git//usr//bin//ssh-agent.exe',
     sshAddCmd: 'c://progra~1//git//usr//bin//ssh-add.exe',
-    gitCmd: 'c://progra~1//git//usr//bin//git.exe'
+    gitCmd: 'c://progra~1//git//bin//git.exe'
 };
 
 

--- a/paths.js
+++ b/paths.js
@@ -12,5 +12,5 @@ module.exports = (process.env['OS'] != 'Windows_NT') ? {
     homePath: os.homedir(),
     sshAgentCmd: 'c://progra~1//git//usr//bin//ssh-agent.exe',
     sshAddCmd: 'c://progra~1//git//usr//bin//ssh-add.exe',
-    gitCmd: 'c://progra~1//git//usr//bin//git.exe'
+    gitCmd: 'c://progra~1//git//bin//git.exe'
 };


### PR DESCRIPTION
This PR fixes an apparently wrong path to the `git` binary that was added in #136. 

According to https://github.com/actions/checkout/discussions/928#discussioncomment-3861581, the path should not contain the `usr/` part, although for `ssh-add` and `ssh-agent`, it has to.