### PR TITLE
Use cygpath to convert socket filename on windows

### DIFF
--- a/dist/cleanup.js
+++ b/dist/cleanup.js
@@ -2835,7 +2835,8 @@ module.exports = (process.env['OS'] != 'Windows_NT') ? {
     homePath: os.homedir(),
     sshAgentCmd: 'c://progra~1//git//usr//bin//ssh-agent.exe',
     sshAddCmd: 'c://progra~1//git//usr//bin//ssh-add.exe',
-    gitCmd: 'c://progra~1//git//bin//git.exe'
+    gitCmd: 'c://progra~1//git//bin//git.exe',
+    pathsCmd: 'c://progra~1//git//usr//bin//cygpath.exe'
 };
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -322,7 +322,7 @@ const core = __webpack_require__(470);
 const child_process = __webpack_require__(129);
 const fs = __webpack_require__(747);
 const crypto = __webpack_require__(417);
-const { homePath, sshAgentCmd, sshAddCmd, gitCmd } = __webpack_require__(972);
+const { homePath, sshAgentCmd, sshAddCmd, gitCmd, pathsCmd } = __webpack_require__(972);
 
 try {
     const privateKey = core.getInput('ssh-private-key');
@@ -353,6 +353,10 @@ try {
         const matches = /^(SSH_AUTH_SOCK|SSH_AGENT_PID)=(.*); export \1/.exec(line);
 
         if (matches && matches.length > 0) {
+            // use pathsCmd to convert socket file to a windows path
+            if (pathsCmd && matches[1] === "SSH_AUTH_SOCK") {
+                matches[2] = child_process.execFileSync(pathsCmd, ['-m', matches[2]]).toString().trim()
+            }
             // This will also set process.env accordingly, so changes take effect for this script
             core.exportVariable(matches[1], matches[2])
             console.log(`${matches[1]}=${matches[2]}`);
@@ -2914,7 +2918,8 @@ module.exports = (process.env['OS'] != 'Windows_NT') ? {
     homePath: os.homedir(),
     sshAgentCmd: 'c://progra~1//git//usr//bin//ssh-agent.exe',
     sshAddCmd: 'c://progra~1//git//usr//bin//ssh-add.exe',
-    gitCmd: 'c://progra~1//git//bin//git.exe'
+    gitCmd: 'c://progra~1//git//bin//git.exe',
+    pathsCmd: 'c://progra~1//git//usr//bin//cygpath.exe'
 };
 
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const core = require('@actions/core');
 const child_process = require('child_process');
 const fs = require('fs');
 const crypto = require('crypto');
-const { homePath, sshAgentCmd, sshAddCmd, gitCmd } = require('./paths.js');
+const { homePath, sshAgentCmd, sshAddCmd, gitCmd, pathsCmd } = require('./paths.js');
 
 try {
     const privateKey = core.getInput('ssh-private-key');
@@ -33,6 +33,10 @@ try {
         const matches = /^(SSH_AUTH_SOCK|SSH_AGENT_PID)=(.*); export \1/.exec(line);
 
         if (matches && matches.length > 0) {
+            // use pathsCmd to convert socket file to a windows path
+            if (pathsCmd && matches[1] === "SSH_AUTH_SOCK") {
+                matches[2] = child_process.execFileSync(pathsCmd, ['-m', matches[2]]).toString().trim()
+            }
             // This will also set process.env accordingly, so changes take effect for this script
             core.exportVariable(matches[1], matches[2])
             console.log(`${matches[1]}=${matches[2]}`);

--- a/paths.js
+++ b/paths.js
@@ -12,5 +12,6 @@ module.exports = (process.env['OS'] != 'Windows_NT') ? {
     homePath: os.homedir(),
     sshAgentCmd: 'c://progra~1//git//usr//bin//ssh-agent.exe',
     sshAddCmd: 'c://progra~1//git//usr//bin//ssh-add.exe',
-    gitCmd: 'c://progra~1//git//bin//git.exe'
+    gitCmd: 'c://progra~1//git//bin//git.exe',
+    pathsCmd: 'c://progra~1//git//usr//bin//cygpath.exe'
 };


### PR DESCRIPTION
I'm attempting to get `docker build --ssh default` working on Windows, but the `SSH_AUTH_SOCK` value that is created by the Git-for-Windows ssh agent is emitted as a MinGW/MSYS/Cygwin path (starts with `/tmp/...`), so Docker fails with a `ERROR: CreateFile /tmp/ssh-jpa87nA86Pbr/agent.6776: The system cannot find the path specified.` error.

```
Run webfactory/ssh-agent@v0.5.4
Adding GitHub.com keys to C:\Users\***/.ssh/known_hosts
Starting ssh-agent
SSH_AUTH_SOCK=/tmp/ssh-jpa87nA86Pbr/agent.6776
SSH_AGENT_PID=6388
```

Using the included utility `cygpath` to convert it to a Windows path lets Docker find the agent socket file.

```
Run nicksieger/ssh-agent@convert-ssh-socket-windows
Adding GitHub.com keys to C:\Users\***/.ssh/known_hosts
Starting ssh-agent
SSH_AUTH_SOCK=C:/Users/***/AppData/Local/Temp/ssh-QoBZcXy4T7vW/agent.7636
SSH_AGENT_PID=3152
```
