### PR TITLE
Allow the user to override the commands for `git`, `ssh-agent`, and `ssh-add`

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The following inputs can be used to control the action's behavior:
 * `log-public-key`: Set this to `false` if you want to suppress logging of _public_ key information. To simplify debugging and since it contains public key information only, this is turned on by default.
 * `ssh-agent-cmd`: Optional. Use this to specify a custom location for the `ssh-agent` binary.
 * `ssh-add-cmd`: Optional. Use this to specify a custom location for the `ssh-add` binary.
-* `git-cmd`: Optional. Use this to specify a custom location for the `ssh-agent` binary.
+* `git-cmd`: Optional. Use this to specify a custom location for the `git` binary.
 
 ## Exported variables
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ The following inputs can be used to control the action's behavior:
 * `ssh-private-key`: Required. Use this to provide the key(s) to load as GitHub Actions secrets.
 * `ssh-auth-sock`: Can be used to control where the SSH agent socket will be placed. Ultimately affects the `$SSH_AUTH_SOCK` environment variable.
 * `log-public-key`: Set this to `false` if you want to suppress logging of _public_ key information. To simplify debugging and since it contains public key information only, this is turned on by default.
+* `ssh-agent-cmd`: Optional. Use this to specify a custom location for the `ssh-agent` binary.
+* `ssh-add-cmd`: Optional. Use this to specify a custom location for the `ssh-add` binary.
+* `git-cmd`: Optional. Use this to specify a custom location for the `ssh-agent` binary.
 
 ## Exported variables
 

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,15 @@ inputs:
         description: 'Whether or not to log public key fingerprints'
         required: false
         default: true
+    ssh-agent-cmd:
+        description: 'ssh-agent command'
+        required: false
+    ssh-add-cmd:
+        description: 'ssh-add command'
+        required: false
+    git-cmd:
+        description: 'git command'
+        required: false
 runs:
     using: 'node16'
     main: 'dist/index.js'

--- a/dist/cleanup.js
+++ b/dist/cleanup.js
@@ -2827,15 +2827,15 @@ module.exports = (process.env['OS'] != 'Windows_NT') ? {
     // Use getent() system call, since this is what ssh does; makes a difference in Docker-based
     // Action runs, where $HOME is different from the pwent
     homePath: os.userInfo().homedir,
-    sshAgentCmd: 'ssh-agent',
-    sshAddCmd: 'ssh-add',
-    gitCmd: 'git'
+    sshAgentCmdDefault: 'ssh-agent',
+    sshAddCmdDefault: 'ssh-add',
+    gitCmdDefault: 'git'
 } : {
     // Assuming GitHub hosted `windows-*` runners for now
     homePath: os.homedir(),
-    sshAgentCmd: 'c://progra~1//git//usr//bin//ssh-agent.exe',
-    sshAddCmd: 'c://progra~1//git//usr//bin//ssh-add.exe',
-    gitCmd: 'c://progra~1//git//bin//git.exe'
+    sshAgentCmdDefault: 'c://progra~1//git//usr//bin//ssh-agent.exe',
+    sshAddCmdDefault: 'c://progra~1//git//usr//bin//ssh-add.exe',
+    gitCmdDefault: 'c://progra~1//git//bin//git.exe'
 };
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -322,11 +322,19 @@ const core = __webpack_require__(470);
 const child_process = __webpack_require__(129);
 const fs = __webpack_require__(747);
 const crypto = __webpack_require__(417);
-const { homePath, sshAgentCmd, sshAddCmd, gitCmd } = __webpack_require__(972);
+const { homePath, sshAgentCmdDefault, sshAddCmdDefault, gitCmdDefault } = __webpack_require__(972);
 
 try {
     const privateKey = core.getInput('ssh-private-key');
     const logPublicKey = core.getBooleanInput('log-public-key', {default: true});
+
+    const sshAgentCmdInput = core.getInput('ssh-agent-cmd');
+    const sshAddCmdInput = core.getInput('ssh-add-cmd');
+    const gitCmdInput = core.getInput('git-cmd');
+
+    const sshAgentCmd = sshAgentCmdInput ? sshAgentCmdInput : sshAgentCmdDefault
+    const sshAddCmd = sshAddCmdInput ? sshAddCmdInput : sshAddCmdDefault
+    const gitCmd = gitCmdInput ? gitCmdInput : gitCmdDefault
 
     if (!privateKey) {
         core.setFailed("The ssh-private-key argument is empty. Maybe the secret has not been configured, or you are using a wrong secret name in your workflow file.");
@@ -2906,15 +2914,15 @@ module.exports = (process.env['OS'] != 'Windows_NT') ? {
     // Use getent() system call, since this is what ssh does; makes a difference in Docker-based
     // Action runs, where $HOME is different from the pwent
     homePath: os.userInfo().homedir,
-    sshAgentCmd: 'ssh-agent',
-    sshAddCmd: 'ssh-add',
-    gitCmd: 'git'
+    sshAgentCmdDefault: 'ssh-agent',
+    sshAddCmdDefault: 'ssh-add',
+    gitCmdDefault: 'git'
 } : {
     // Assuming GitHub hosted `windows-*` runners for now
     homePath: os.homedir(),
-    sshAgentCmd: 'c://progra~1//git//usr//bin//ssh-agent.exe',
-    sshAddCmd: 'c://progra~1//git//usr//bin//ssh-add.exe',
-    gitCmd: 'c://progra~1//git//bin//git.exe'
+    sshAgentCmdDefault: 'c://progra~1//git//usr//bin//ssh-agent.exe',
+    sshAddCmdDefault: 'c://progra~1//git//usr//bin//ssh-add.exe',
+    gitCmdDefault: 'c://progra~1//git//bin//git.exe'
 };
 
 

--- a/index.js
+++ b/index.js
@@ -12,9 +12,9 @@ try {
     const sshAddCmdInput = core.getInput('ssh-add-cmd');
     const gitCmdInput = core.getInput('git-cmd');
 
-    const sshAgentCmd = sshAgentCmdInput ? sshAgentCmdInput : sshAgentCmdDefault
-    const sshAddCmd = sshAddCmdInput ? sshAddCmdInput : sshAddCmdDefault
-    const gitCmd = gitCmdInput ? gitCmdInput : gitCmdDefault
+    const sshAgentCmd = sshAgentCmdInput ? sshAgentCmdInput : sshAgentCmdDefault;
+    const sshAddCmd = sshAddCmdInput ? sshAddCmdInput : sshAddCmdDefault;
+    const gitCmd = gitCmdInput ? gitCmdInput : gitCmdDefault;
 
     if (!privateKey) {
         core.setFailed("The ssh-private-key argument is empty. Maybe the secret has not been configured, or you are using a wrong secret name in your workflow file.");

--- a/index.js
+++ b/index.js
@@ -2,11 +2,19 @@ const core = require('@actions/core');
 const child_process = require('child_process');
 const fs = require('fs');
 const crypto = require('crypto');
-const { homePath, sshAgentCmd, sshAddCmd, gitCmd } = require('./paths.js');
+const { homePath, sshAgentCmdDefault, sshAddCmdDefault, gitCmdDefault } = require('./paths.js');
 
 try {
     const privateKey = core.getInput('ssh-private-key');
     const logPublicKey = core.getBooleanInput('log-public-key', {default: true});
+
+    const sshAgentCmdInput = core.getInput('ssh-agent-cmd');
+    const sshAddCmdInput = core.getInput('ssh-add-cmd');
+    const gitCmdInput = core.getInput('git-cmd');
+
+    const sshAgentCmd = sshAgentCmdInput ? sshAgentCmdInput : sshAgentCmdDefault
+    const sshAddCmd = sshAddCmdInput ? sshAddCmdInput : sshAddCmdDefault
+    const gitCmd = gitCmdInput ? gitCmdInput : gitCmdDefault
 
     if (!privateKey) {
         core.setFailed("The ssh-private-key argument is empty. Maybe the secret has not been configured, or you are using a wrong secret name in your workflow file.");

--- a/paths.js
+++ b/paths.js
@@ -4,13 +4,13 @@ module.exports = (process.env['OS'] != 'Windows_NT') ? {
     // Use getent() system call, since this is what ssh does; makes a difference in Docker-based
     // Action runs, where $HOME is different from the pwent
     homePath: os.userInfo().homedir,
-    sshAgentCmd: 'ssh-agent',
-    sshAddCmd: 'ssh-add',
-    gitCmd: 'git'
+    sshAgentCmdDefault: 'ssh-agent',
+    sshAddCmdDefault: 'ssh-add',
+    gitCmdDefault: 'git'
 } : {
     // Assuming GitHub hosted `windows-*` runners for now
     homePath: os.homedir(),
-    sshAgentCmd: 'c://progra~1//git//usr//bin//ssh-agent.exe',
-    sshAddCmd: 'c://progra~1//git//usr//bin//ssh-add.exe',
-    gitCmd: 'c://progra~1//git//bin//git.exe'
+    sshAgentCmdDefault: 'c://progra~1//git//usr//bin//ssh-agent.exe',
+    sshAddCmdDefault: 'c://progra~1//git//usr//bin//ssh-add.exe',
+    gitCmdDefault: 'c://progra~1//git//bin//git.exe'
 };


### PR DESCRIPTION
On my self-hosted Windows runners, the `git`, `ssh-agent`, and `ssh-add` commands are not located in the locations that are currently hard-coded in `paths.js`.

With this PR, I am able to get this action to work on my runners as follows:

```yaml
- uses: webfactory/ssh-agent@...
  with:
    ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
    git-cmd: git
    ssh-agent-cmd: ssh-agent
    ssh-add-cmd: ssh-add
```