### PR TITLE
support GitHub Enterprise servers

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -380,7 +380,7 @@ try {
     console.log('Configuring deployment key(s)');
 
     child_process.execFileSync(sshAddCmd, ['-L']).toString().trim().split(/\r?\n/).forEach(function(key) {
-        const parts = key.match(/\bgithub\.com[:/]([_.a-z0-9-]+\/[_.a-z0-9-]+)/i);
+        const parts = key.match(/\b([\w.]+)[:/]([_.a-z0-9-]+\/[_.a-z0-9-]+)$/i);
 
         if (!parts) {
             if (logPublicKey) {
@@ -390,16 +390,17 @@ try {
         }
 
         const sha256 = crypto.createHash('sha256').update(key).digest('hex');
-        const ownerAndRepo = parts[1].replace(/\.git$/, '');
+        const githubHost = parts[1];
+        const ownerAndRepo = parts[2].replace(/\.git$/, '');
 
         fs.writeFileSync(`${homeSsh}/key-${sha256}`, key + "\n", { mode: '600' });
 
-        child_process.execSync(`${gitCmd} config --global --replace-all url."git@key-${sha256}.github.com:${ownerAndRepo}".insteadOf "https://github.com/${ownerAndRepo}"`);
-        child_process.execSync(`${gitCmd} config --global --add url."git@key-${sha256}.github.com:${ownerAndRepo}".insteadOf "git@github.com:${ownerAndRepo}"`);
-        child_process.execSync(`${gitCmd} config --global --add url."git@key-${sha256}.github.com:${ownerAndRepo}".insteadOf "ssh://git@github.com/${ownerAndRepo}"`);
+        child_process.execSync(`${gitCmd} config --global --replace-all url."git@key-${sha256}.${githubHost}:${ownerAndRepo}".insteadOf "https://${githubHost}/${ownerAndRepo}"`);
+        child_process.execSync(`${gitCmd} config --global --add url."git@key-${sha256}.${githubHost}:${ownerAndRepo}".insteadOf "git@${githubHost}:${ownerAndRepo}"`);
+        child_process.execSync(`${gitCmd} config --global --add url."git@key-${sha256}.${githubHost}:${ownerAndRepo}".insteadOf "ssh://git@${githubHost}/${ownerAndRepo}"`);
 
-        const sshConfig = `\nHost key-${sha256}.github.com\n`
-                              + `    HostName github.com\n`
+        const sshConfig = `\nHost key-${sha256}.${githubHost}\n`
+                              + `    HostName ${githubHost}\n`
                               + `    IdentityFile ${homeSsh}/key-${sha256}\n`
                               + `    IdentitiesOnly yes\n`;
 

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ try {
     console.log('Configuring deployment key(s)');
 
     child_process.execFileSync(sshAddCmd, ['-L']).toString().trim().split(/\r?\n/).forEach(function(key) {
-        const parts = key.match(/\bgithub\.com[:/]([_.a-z0-9-]+\/[_.a-z0-9-]+)/i);
+        const parts = key.match(/\b([\w.]+)[:/]([_.a-z0-9-]+\/[_.a-z0-9-]+)$/i);
 
         if (!parts) {
             if (logPublicKey) {
@@ -70,16 +70,17 @@ try {
         }
 
         const sha256 = crypto.createHash('sha256').update(key).digest('hex');
-        const ownerAndRepo = parts[1].replace(/\.git$/, '');
+        const githubHost = parts[1];
+        const ownerAndRepo = parts[2].replace(/\.git$/, '');
 
         fs.writeFileSync(`${homeSsh}/key-${sha256}`, key + "\n", { mode: '600' });
 
-        child_process.execSync(`${gitCmd} config --global --replace-all url."git@key-${sha256}.github.com:${ownerAndRepo}".insteadOf "https://github.com/${ownerAndRepo}"`);
-        child_process.execSync(`${gitCmd} config --global --add url."git@key-${sha256}.github.com:${ownerAndRepo}".insteadOf "git@github.com:${ownerAndRepo}"`);
-        child_process.execSync(`${gitCmd} config --global --add url."git@key-${sha256}.github.com:${ownerAndRepo}".insteadOf "ssh://git@github.com/${ownerAndRepo}"`);
+        child_process.execSync(`${gitCmd} config --global --replace-all url."git@key-${sha256}.${githubHost}:${ownerAndRepo}".insteadOf "https://${githubHost}/${ownerAndRepo}"`);
+        child_process.execSync(`${gitCmd} config --global --add url."git@key-${sha256}.${githubHost}:${ownerAndRepo}".insteadOf "git@${githubHost}:${ownerAndRepo}"`);
+        child_process.execSync(`${gitCmd} config --global --add url."git@key-${sha256}.${githubHost}:${ownerAndRepo}".insteadOf "ssh://git@${githubHost}/${ownerAndRepo}"`);
 
-        const sshConfig = `\nHost key-${sha256}.github.com\n`
-                              + `    HostName github.com\n`
+        const sshConfig = `\nHost key-${sha256}.${githubHost}\n`
+                              + `    HostName ${githubHost}\n`
                               + `    IdentityFile ${homeSsh}/key-${sha256}\n`
                               + `    IdentitiesOnly yes\n`;
 


### PR DESCRIPTION
Added support for GitHub Enterprise servers by loosening the restrictions on the hostname portion of the deploy key comment being "github.com" to any hostname and then using that hostname in the rest of the config. Adjusted the regex to match the end of the line since the comment portion is at the end. fixes #934