### PR TITLE
Fix README for using multiple deploy keys in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ Dockerfile:
 # Copy the two files in place and fix different path/locations inside the Docker image
 COPY root-config /root/
 RUN sed 's|/home/runner|/root|g' -i.bak /root/.ssh/config
+# Move the .gitconfig into the default path for git system config location
+RUN mv /root/.gitconfig /etc/gitconfig
 ```
 
 Keep in mind that the resulting Docker image now might contain these customized Git and SSH configuration files! Your private SSH keys are never written to files anywhere, just loaded into the SSH agent and forwarded into the container. The config files might, however, give away details about your build or development process and contain the names and URLs of your (private) repositories. You might want to use a multi-staged build to make sure these files do not end up in the final image.


### PR DESCRIPTION
## TL;DR;
Multiple deploy keys in docker doesn't work after following everything in README. Loading `.gitconfig` into git in docker fixed it.

## Summary
We are using multiple Github deploy keys in docker for PIP to install dependencies from multiple private Github repositories. However, after doing everything from the webfactory/ssh-agent README, including adding comment when generating keys and copying `.gitconfig` and `.ssh/` into docker, the multiple deploy keys still didn't work. We print out the verbose log for `git ssh` when doing PIP install by using `RUN --mount=type=ssh GIT_SSH_COMMAND="ssh -v" pip install -r /requirements.txt`. Turns out that it was blindly accepting the first key (repo-a) even though it should use the second key (repo-b) which is way it couldn't fetch from the repo-b. After some research, the webfactory/ssh-agent depends on the customized `.gitconfig` file to map the correct ssh key to the correct repository link. Then we did a `RUN git config -l` in the Dockerfile and the output was empty which means that although we are copying the `.gitconfig` file into the docker image, it was not loaded into git config. So after adding `RUN mv /root/.gitconfig /etc/gitconfig` into the Dockerfile, the PIP install started working. In conclusion, the `.gitconfig` config file doesn't do anything sitting in the `/root` folder.

### Following was the original error message excluding sensitive information that helped us figure out the root cause:
```
#24 3.926   debug1: Will attempt key: git@github.com:owner/repo-a.git ED25519 SHA256:*** agent
#24 3.927   debug1: Will attempt key: git@github.com:owner/repo-b.git ED25519 SHA256:*** agent
...
#24 4.013   debug1: Authentications that can continue: publickey
#24 4.014   debug1: Next authentication method: publickey
#24 4.014   debug1: Offering public key: git@github.com:owner/repo-a.git ED25519 SHA256:*** agent
#24 4.047   debug1: Server accepts key: git@github.com:owner/repo-a.git ED25519 SHA256:*** agent
#24 4.076   debug1: Authentication succeeded (publickey).
#24 4.077   Authenticated to github.com ([140.82.112.3]:22).
#24 4.078   debug1: channel 0: new [client-session]
#24 4.079   debug1: Entering interactive session.
#24 4.079   debug1: pledge: network
#24 4.099   debug1: client_input_global_request: rtype hostkeys-00@openssh.com want_reply 0
#24 4.143   debug1: Sending environment.
#24 4.144   debug1: Sending env GIT_PROTOCOL = version=2
#24 4.145   debug1: Sending env LANG = C.UTF-8
#24 4.146   debug1: Sending command: git-upload-pack '/owner/repo-b.git'
#24 4.207   debug1: client_input_channel_req: channel 0 rtype exit-status reply 0
#24 4.207   ERROR: Repository not found.
```

### Following was the log of successfully using multiple deploy keys in docker:
```
#28 5.568   debug1: Will attempt key: /root/.ssh/key-*** (repo-b) ED25519 SHA256:*** explicit agent
...
#28 5.722   debug1: Authentications that can continue: publickey
#28 5.722   debug1: Next authentication method: publickey
#28 5.722   debug1: Offering public key: /root/.ssh/key-*** (repo-b) ED25519 SHA256:*** explicit agent
#28 5.786   debug1: Server accepts key: /root/.ssh/key-*** (repo-b) ED25519 SHA256:*** explicit agent
#28 5.846   debug1: Authentication succeeded (publickey).
#28 5.846   Authenticated to github.com ([140.82.113.4]:22).
#28 5.847   debug1: channel 0: new [client-session]
#28 5.847   debug1: Entering interactive session.
#28 5.848   debug1: pledge: network
#28 5.848   debug1: client_input_global_request: rtype hostkeys-00@openssh.com want_reply 0
#28 5.901   debug1: Sending environment.
#28 5.901   debug1: Sending env GIT_PROTOCOL = version=2
#28 5.902   debug1: Sending env LANG = C.UTF-8
#28 5.902   debug1: Sending command: git-upload-pack 'owner/repo-b.git'
#28 6.414   debug1: client_input_channel_req: channel 0 rtype exit-status reply 0
#28 6.415   debug1: channel 0: free: client-session, nchannels 1
#28 6.416   debug1: fd 0 clearing O_NONBLOCK
#28 6.416   debug1: fd 2 clearing O_NONBLOCK
#28 6.417   Transferred: sent 12836, received 265192 bytes, in 0.6 seconds
#28 6.417   Bytes per second: sent 22608.0, received 467080.7
#28 6.418   debug1: Exit status 0
```

## Example Github Actions YAML
```
name: Docker Build and Push
on: workflow_dispatch
jobs:
  build_docker:
    name: Build Docker Image and Push
    runs-on: ubuntu-latest
    timeout-minutes: 90
    environment: "some_env"
    steps:
      - name: Checkout
        uses: actions/checkout@v3

      - name: Install SSH key
        uses: webfactory/ssh-agent@v0.7.0
        with:
           ssh-private-key: |
               ${{ secrets.KEY_FOR_REPO_A }}
               ${{ secrets.KEY_FOR_REPO_B }}
           ssh-auth-sock: /tmp/ssh_agent.sock

      - name: Collect necessary files for copying into docker image
        run: |
          mkdir build/some_folder/root-config
          cp -r ~/.gitconfig ~/.ssh build/some_folder/root-config
...
      - name: Build and Push Docker
        uses: docker/build-push-action@v4
        with:
          context: build/some_folder
          file: some_folder/Dockerfile
          platforms: linux/amd64,linux/arm64
          cache-from: type=registry,ref=some_registry/some_repository:cache
          cache-to: type=registry,ref=some_registry/some_repository:cache
          ssh: default=${{ env.SSH_AUTH_SOCK }}
          push: true
          tags: some_registry/some_repository:cache:latest
```

## Example Dockerfile
```
...
COPY /root-config /root/
RUN sed 's|/home/runner|/root|g' -i.bak /root/.ssh/config
RUN mv /root/.gitconfig /etc/gitconfig
RUN --mount=type=ssh pip install -r /requirements.txt
...
```

## Example PIP requirements.txt
```
git+ssh://git@github.com/owner/repo-a
git+ssh://git@github.com/owner/repo-b

<other python dependencies>
...
```