### PR TITLE
add option use-base64 for encoded key

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -342,6 +342,7 @@ const { homePath, sshAgentCmdDefault, sshAddCmdDefault, gitCmdDefault } = __webp
 
 try {
     const privateKey = core.getInput('ssh-private-key');
+    const useBase64 = core.getInput('use-base64');
     const logPublicKey = core.getBooleanInput('log-public-key', {default: true});
 
     const sshAgentCmdInput = core.getInput('ssh-agent-cmd');
@@ -379,7 +380,12 @@ try {
 
     console.log("Adding private key(s) to agent");
 
-    privateKey.split(/(?=-----BEGIN)/).forEach(function(key) {
+    let decodedPrivateKey = privateKey;
+    // base64 decode privateKey
+    if (useBase64 === 'true') {
+        decodedPrivateKey = Buffer.from(privateKey, 'base64').toString('utf8');
+    }
+    decodedPrivateKey.split(/(?=-----BEGIN)/).forEach(function(key) {
         child_process.execFileSync(sshAddCmd, ['-'], { input: key.trim() + "\n" });
     });
 

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const { homePath, sshAgentCmdDefault, sshAddCmdDefault, gitCmdDefault } = requir
 
 try {
     const privateKey = core.getInput('ssh-private-key');
+    const useBase64 = core.getInput('use-base64');
     const logPublicKey = core.getBooleanInput('log-public-key', {default: true});
 
     const sshAgentCmdInput = core.getInput('ssh-agent-cmd');
@@ -43,7 +44,12 @@ try {
 
     console.log("Adding private key(s) to agent");
 
-    privateKey.split(/(?=-----BEGIN)/).forEach(function(key) {
+    let decodedPrivateKey = privateKey;
+    // base64 decode privateKey
+    if (useBase64 === 'true') {
+        decodedPrivateKey = Buffer.from(privateKey, 'base64').toString('utf8');
+    }
+    decodedPrivateKey.split(/(?=-----BEGIN)/).forEach(function(key) {
         child_process.execFileSync(sshAddCmd, ['-'], { input: key.trim() + "\n" });
     });
 


### PR DESCRIPTION
Hello,

we try to use [act](https://github.com/nektos/act) to run a workflow locally. The problem is, in `act` we can not input the ssh-key as secret as multi-lines using the `.actrc` config file. One solution is, the ssh-key is base64 encoded and can be passed to `act` using the `.actrc` file. From the action `ssh-agent` the string will be base64 decoded before it is passed to the command `ssh-agent - ...`. 

This behaviour is controlled by an additional option `use-base64`. 

Please review the changes and make a decision ob this PR should be merged. Thanks!  

Best regards,
Li Sheng