### PR TITLE
chore: update all versions of `actions/checkout` to v4

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -8,7 +8,7 @@ jobs:
                 os: [ ubuntu-latest, macOS-latest, windows-latest ]
         runs-on: ${{ matrix.os }}
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
             -   name: Setup key
                 uses: ./
                 with:
@@ -28,7 +28,7 @@ jobs:
         container:
             image: ubuntu:latest
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
             -   run: apt update && apt install -y openssh-client git
             -   name: Setup key
                 uses: ./

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ GitHub Actions only have access to the repository they run for. So, in order to 
     * In your repository, go to the *Settings > Secrets* menu and create a new secret. In this example, we'll call it `SSH_PRIVATE_KEY`. 
     * Put the contents of the *private* SSH key file into the contents field. <br>
     * This key should start with `-----BEGIN ... PRIVATE KEY-----`, consist of many lines and ends with `-----END ... PRIVATE KEY-----`. 
-5. In your workflow definition file, add the following step. Preferably this would be rather on top, near the `actions/checkout@v2` line.
+5. In your workflow definition file, add the following step. Preferably this would be rather on top, near the `actions/checkout@v4` line.
 
 ```yaml
 # .github/workflows/my-workflow.yml
@@ -35,7 +35,7 @@ jobs:
     my_job:
         ...
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             # Make sure the @v0.8.0 matches the current version of the action
             - uses: webfactory/ssh-agent@v0.8.0
               with:


### PR DESCRIPTION
In this PR, I update the `actions/checkout` versions. When I recently started using this action, I was confused about whether it works with the newest checkout action. I tested it and everything is fine. For future users, we should display examples with the newest versions.