### PR TITLE
bump to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,10 +20,11 @@ inputs:
         description: 'git command'
         required: false
 runs:
-    using: 'node16'
+    using: 'node20'
     main: 'dist/index.js'
     post: 'dist/cleanup.js'
     post-if: 'always()'
+
 branding:
     icon: loader
     color: 'yellow'


### PR DESCRIPTION
Fix for deprecated node16

Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: webfactory/ssh-agent@v0.8.0. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/