### PR TITLE
Make instance URL configurable to support other Git vendors or github enterprise on prem

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ To support picking the right key in this use case, this action scans _key commen
 
 The following inputs can be used to control the action's behavior:
 
+* `instance-domain`: Optional. The domain name of the github/gitea/forgejo instance. Defaults to `github.com`.
 * `ssh-private-key`: Required. Use this to provide the key(s) to load as GitHub Actions secrets.
 * `ssh-auth-sock`: Can be used to control where the SSH agent socket will be placed. Ultimately affects the `$SSH_AUTH_SOCK` environment variable.
 * `log-public-key`: Set this to `false` if you want to suppress logging of _public_ key information. To simplify debugging and since it contains public key information only, this is turned on by default.

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,9 @@
 name: 'webfactory/ssh-agent'
 description: 'Run `ssh-agent` and load an SSH key to access other private repositories'
 inputs:
+    instance-domain:
+        description: 'Domain name of the instance (gitea/forgejo)'
+        required: false
     ssh-private-key:
         description: 'Private SSH key to register in the SSH agent'
         required: true

--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'webfactory/ssh-agent'
 description: 'Run `ssh-agent` and load an SSH key to access other private repositories'
 inputs:
     instance-domain:
-        description: 'Domain name of the instance (gitea/forgejo)'
+        description: 'Domain name of the github/gitea/forgejo instance'
         required: false
     ssh-private-key:
         description: 'Private SSH key to register in the SSH agent'

--- a/dist/index.js
+++ b/dist/index.js
@@ -394,6 +394,7 @@ try {
     console.log('Configuring deployment key(s)');
 
     child_process.execFileSync(sshAddCmd, ['-L']).toString().trim().split(/\r?\n/).forEach(function(key) {
+        console.log('Domain regular expression is:', regexDomain);
         const parts = key.match(regexDomain);
 
         if (!parts) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -341,7 +341,8 @@ const crypto = __webpack_require__(417);
 const { homePath, sshAgentCmdDefault, sshAddCmdDefault, gitCmdDefault } = __webpack_require__(972);
 
 try {
-    const instanceDomain = core.getInput('instance-domain', {default: 'github.com'});
+    const instanceURL = core.getInput('instance-url') || process.env.GITHUB_SERVER_URL || 'https://github.com';
+    const instanceDomain = instanceURL.replace(/^https?:\/\//, '');
     const escapedDomain = instanceDomain.replace(/[-.]/g, '\\$&');
     const regexDomain = new RegExp(`\\b${escapedDomain}[:/]([_.a-z0-9-]+\/[_.a-z0-9-]+)`, 'i');
 
@@ -394,7 +395,7 @@ try {
     console.log('Configuring deployment key(s)');
 
     child_process.execFileSync(sshAddCmd, ['-L']).toString().trim().split(/\r?\n/).forEach(function(key) {
-        console.log('Domain regular expression is:', regexDomain);
+        console.log('Instance domain is:', instanceDomain);
         const parts = key.match(regexDomain);
 
         if (!parts) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -341,6 +341,10 @@ const crypto = __webpack_require__(417);
 const { homePath, sshAgentCmdDefault, sshAddCmdDefault, gitCmdDefault } = __webpack_require__(972);
 
 try {
+    const instanceDomain = core.getInput('instance-domain', {default: 'github.com'});
+    const escapedDomain = instanceDomain.replace(/[-.]/g, '\\$&');
+    const regexDomain = new RegExp(`\\b${escapedDomain}[:/]([_.a-z0-9-]+\/[_.a-z0-9-]+)`, 'i');
+
     const privateKey = core.getInput('ssh-private-key');
     const logPublicKey = core.getBooleanInput('log-public-key', {default: true});
 
@@ -390,7 +394,7 @@ try {
     console.log('Configuring deployment key(s)');
 
     child_process.execFileSync(sshAddCmd, ['-L']).toString().trim().split(/\r?\n/).forEach(function(key) {
-        const parts = key.match(/\bgithub\.com[:/]([_.a-z0-9-]+\/[_.a-z0-9-]+)/i);
+        const parts = key.match(regexDomain);
 
         if (!parts) {
             if (logPublicKey) {
@@ -404,12 +408,12 @@ try {
 
         fs.writeFileSync(`${homeSsh}/key-${sha256}`, key + "\n", { mode: '600' });
 
-        child_process.execSync(`${gitCmd} config --global --replace-all url."git@key-${sha256}.github.com:${ownerAndRepo}".insteadOf "https://github.com/${ownerAndRepo}"`);
-        child_process.execSync(`${gitCmd} config --global --add url."git@key-${sha256}.github.com:${ownerAndRepo}".insteadOf "git@github.com:${ownerAndRepo}"`);
-        child_process.execSync(`${gitCmd} config --global --add url."git@key-${sha256}.github.com:${ownerAndRepo}".insteadOf "ssh://git@github.com/${ownerAndRepo}"`);
+        child_process.execSync(`${gitCmd} config --global --replace-all url."git@key-${sha256}.${instanceDomain}:${ownerAndRepo}".insteadOf "https://${instanceDomain}/${ownerAndRepo}"`);
+        child_process.execSync(`${gitCmd} config --global --add url."git@key-${sha256}.${instanceDomain}:${ownerAndRepo}".insteadOf "git@${instanceDomain}:${ownerAndRepo}"`);
+        child_process.execSync(`${gitCmd} config --global --add url."git@key-${sha256}.${instanceDomain}:${ownerAndRepo}".insteadOf "ssh://git@${instanceDomain}/${ownerAndRepo}"`);
 
-        const sshConfig = `\nHost key-${sha256}.github.com\n`
-                              + `    HostName github.com\n`
+        const sshConfig = `\nHost key-${sha256}.${instanceDomain}\n`
+                              + `    HostName ${instanceDomain}\n`
                               + `    IdentityFile ${homeSsh}/key-${sha256}\n`
                               + `    IdentitiesOnly yes\n`;
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ const crypto = require('crypto');
 const { homePath, sshAgentCmdDefault, sshAddCmdDefault, gitCmdDefault } = require('./paths.js');
 
 try {
-    const instanceDomain = core.getInput('instance-domain', {default: 'github.com'});
+    const instanceURL = core.getInput('instance-url') || process.env.GITHUB_SERVER_URL || 'https://github.com';
+    const instanceDomain = instanceURL.replace(/^https?:\/\//, '');
     const escapedDomain = instanceDomain.replace(/[-.]/g, '\\$&');
     const regexDomain = new RegExp(`\\b${escapedDomain}[:/]([_.a-z0-9-]+\/[_.a-z0-9-]+)`, 'i');
 
@@ -58,7 +59,7 @@ try {
     console.log('Configuring deployment key(s)');
 
     child_process.execFileSync(sshAddCmd, ['-L']).toString().trim().split(/\r?\n/).forEach(function(key) {
-        console.log('Domain regular expression is:', regexDomain);
+        console.log('Instance domain is:', instanceDomain);
         const parts = key.match(regexDomain);
 
         if (!parts) {

--- a/index.js
+++ b/index.js
@@ -58,6 +58,7 @@ try {
     console.log('Configuring deployment key(s)');
 
     child_process.execFileSync(sshAddCmd, ['-L']).toString().trim().split(/\r?\n/).forEach(function(key) {
+        console.log('Domain regular expression is:', regexDomain);
         const parts = key.match(regexDomain);
 
         if (!parts) {


### PR DESCRIPTION
Added compatibility with instances of other products that use this action. Now, keys should be correctly processed by comments, regardless of the domain on which the server is deployed. The domain is taken from the GITHUB_SERVER_URL variable. I tested it on forgejo and it works. It should work on gitea too, but I haven't tested it.