### PR TITLE
Do not create ~/.ssh if it's already exists ("mkdir -p" behavior)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Fix path used to execute ssh-agent in cleanup.js to respect custom paths set by input (#235)
+* Fix running with the .ssh directory already existing (#234)
 
 ## v0.9.0 [2024-02-06]
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -335,7 +335,9 @@ try {
     }
 
     const homeSsh = homePath + '/.ssh';
-    fs.mkdirSync(homeSsh, { recursive: true });
+    if (!fs.existsSync(buildDir)) {
+        fs.mkdirSync(homeSsh, { recursive: true });
+    }
 
     console.log("Starting ssh-agent");
 

--- a/index.js
+++ b/index.js
@@ -23,7 +23,9 @@ try {
     }
 
     const homeSsh = homePath + '/.ssh';
-    fs.mkdirSync(homeSsh, { recursive: true });
+    if (!fs.existsSync(buildDir)) {
+        fs.mkdirSync(homeSsh, { recursive: true });
+    }
 
     console.log("Starting ssh-agent");
 


### PR DESCRIPTION
Otherwise the actions fails with `EEXIST` if `~/.ssh` directory already exists.

This is similar to how `buildsDir` is created: https://github.com/webfactory/ssh-agent/blob/5fedeb584e8c6b8608a5a06dbca73b68ea95fea7/scripts/build.js#L18-L20