### PR TITLE
Support Forgejo (& GHES?)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ The following inputs can be used to control the action's behavior:
 
 * `ssh-private-key`: Required. Use this to provide the key(s) to load as GitHub Actions secrets.
 * `ssh-auth-sock`: Can be used to control where the SSH agent socket will be placed. Ultimately affects the `$SSH_AUTH_SOCK` environment variable.
+* `instance-urls`: Can be used to determine what Git provider URLs to check keys against. Defaults to `github.com`.
 * `log-public-key`: Set this to `false` if you want to suppress logging of _public_ key information. To simplify debugging and since it contains public key information only, this is turned on by default.
 * `ssh-agent-cmd`: Optional. Use this to specify a custom location for the `ssh-agent` binary.
 * `ssh-add-cmd`: Optional. Use this to specify a custom location for the `ssh-add` binary.

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,18 @@ inputs:
         required: true
     ssh-auth-sock:
         description: 'Where to place the SSH Agent auth socket'
+    instance-urls:
+        description: |-
+          URL(s) of the Git provider instance(s) to use.
+          You can specify multiple instance URls by putting each one on a separate line.
+          ```yaml
+          instance-urls: |-
+              github.com
+              code.forgejo.org
+              codeberg.org
+          ```
+        required: false
+        default: 'github.com'
     log-public-key:
         description: 'Whether or not to log public key fingerprints'
         required: false


### PR DESCRIPTION
Currently, this action uses regex to check specifically for `github.com`. This means that part of this action's functionality cannot be used in its current state on other platforms, or in GitHub's own enterprise selfhosting version. This PR adds support for non-GitHub providers, although I've only specifically tested it with Forgejo.