### PR TITLE
Change the identify file path from hardcoded absolute to user based

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ try {
 
         const sshConfig = `\nHost key-${sha256}.github.com\n`
                               + `    HostName github.com\n`
-                              + `    IdentityFile ${homeSsh}/key-${sha256}\n`
+                              + `    IdentityFile ~/.ssh/key-${sha256}\n`
                               + `    IdentitiesOnly yes\n`;
 
         fs.appendFileSync(`${homeSsh}/config`, sshConfig);


### PR DESCRIPTION
## Issue

The issue is that a hardcoded full path of the identity file inside of the ssh config is in case of a github action run something like `/home/runner`.
If you need that file inside of a docker build system you can not simply mount that file into the container. You need to copy the file, sed it (string replace) and then mount it.

If we would use something like a "home dir" placeholder this would work out of the box.

Not sure if ~ works in all cases but %d should.

https://linux.die.net/man/5/ssh_config