### PR TITLE
add home-path input for GH runners using DynamicUser

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The following inputs can be used to control the action's behavior:
 * `ssh-agent-cmd`: Optional. Use this to specify a custom location for the `ssh-agent` binary.
 * `ssh-add-cmd`: Optional. Use this to specify a custom location for the `ssh-add` binary.
 * `git-cmd`: Optional. Use this to specify a custom location for the `git` binary.
+* `home-path`: Optional. Use this to override user home directory.
 
 ## Exported variables
 

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
     git-cmd:
         description: 'git command'
         required: false
+    home-path:
+        description: 'User home directory override'
+        required: false
 runs:
     using: 'node24'
     main: 'dist/index.js'

--- a/dist/cleanup.js
+++ b/dist/cleanup.js
@@ -2824,15 +2824,16 @@ const os = __webpack_require__(87);
 const core = __webpack_require__(470);
 
 const defaults = (process.env['OS'] != 'Windows_NT') ? {
-    // Use getent() system call, since this is what ssh does; makes a difference in Docker-based
-    // Action runs, where $HOME is different from the pwent
-    homePath: os.userInfo().homedir,
+    // We use os.userInfo() rather than os.homedir(), since it uses the getpwuid() system call to get the user's home directory (see https://nodejs.org/api/os.html#osuserinfooptions).
+    // This mimics the way openssh derives the home directory for locating config files (see https://github.com/openssh/openssh-portable/blob/826483d51a9fee60703298bbf839d9ce37943474/ssh.c#L710);
+    // Makes a difference in Docker-based Action runs, when $HOME is different from what getpwuid() returns (which is based on the entry in /etc/passwd)
+    homePathDefault: os.userInfo().homedir,
     sshAgentCmdDefault: 'ssh-agent',
     sshAddCmdDefault: 'ssh-add',
     gitCmdDefault: 'git'
 } : {
     // Assuming GitHub hosted `windows-*` runners for now
-    homePath: os.homedir(),
+    homePathDefault: os.homedir(),
     sshAgentCmdDefault: 'c://progra~1//git//usr//bin//ssh-agent.exe',
     sshAddCmdDefault: 'c://progra~1//git//usr//bin//ssh-add.exe',
     gitCmdDefault: 'c://progra~1//git//bin//git.exe'
@@ -2841,9 +2842,10 @@ const defaults = (process.env['OS'] != 'Windows_NT') ? {
 const sshAgentCmdInput = core.getInput('ssh-agent-cmd');
 const sshAddCmdInput = core.getInput('ssh-add-cmd');
 const gitCmdInput = core.getInput('git-cmd');
+const homePathInput = core.getInput('home-path');
 
 module.exports = {
-    homePath: defaults.homePath,
+    homePath: homePathInput !== '' ? homePathInput : defaults.homePathDefault,
     sshAgentCmd: sshAgentCmdInput !== '' ? sshAgentCmdInput : defaults.sshAgentCmdDefault,
     sshAddCmd: sshAddCmdInput !== '' ? sshAddCmdInput : defaults.sshAddCmdDefault,
     gitCmd: gitCmdInput !== '' ? gitCmdInput : defaults.gitCmdDefault,

--- a/dist/index.js
+++ b/dist/index.js
@@ -2898,15 +2898,16 @@ const os = __webpack_require__(87);
 const core = __webpack_require__(470);
 
 const defaults = (process.env['OS'] != 'Windows_NT') ? {
-    // Use getent() system call, since this is what ssh does; makes a difference in Docker-based
-    // Action runs, where $HOME is different from the pwent
-    homePath: os.userInfo().homedir,
+    // We use os.userInfo() rather than os.homedir(), since it uses the getpwuid() system call to get the user's home directory (see https://nodejs.org/api/os.html#osuserinfooptions).
+    // This mimics the way openssh derives the home directory for locating config files (see https://github.com/openssh/openssh-portable/blob/826483d51a9fee60703298bbf839d9ce37943474/ssh.c#L710);
+    // Makes a difference in Docker-based Action runs, when $HOME is different from what getpwuid() returns (which is based on the entry in /etc/passwd)
+    homePathDefault: os.userInfo().homedir,
     sshAgentCmdDefault: 'ssh-agent',
     sshAddCmdDefault: 'ssh-add',
     gitCmdDefault: 'git'
 } : {
     // Assuming GitHub hosted `windows-*` runners for now
-    homePath: os.homedir(),
+    homePathDefault: os.homedir(),
     sshAgentCmdDefault: 'c://progra~1//git//usr//bin//ssh-agent.exe',
     sshAddCmdDefault: 'c://progra~1//git//usr//bin//ssh-add.exe',
     gitCmdDefault: 'c://progra~1//git//bin//git.exe'
@@ -2915,9 +2916,10 @@ const defaults = (process.env['OS'] != 'Windows_NT') ? {
 const sshAgentCmdInput = core.getInput('ssh-agent-cmd');
 const sshAddCmdInput = core.getInput('ssh-add-cmd');
 const gitCmdInput = core.getInput('git-cmd');
+const homePathInput = core.getInput('home-path');
 
 module.exports = {
-    homePath: defaults.homePath,
+    homePath: homePathInput !== '' ? homePathInput : defaults.homePathDefault,
     sshAgentCmd: sshAgentCmdInput !== '' ? sshAgentCmdInput : defaults.sshAgentCmdDefault,
     sshAddCmd: sshAddCmdInput !== '' ? sshAddCmdInput : defaults.sshAddCmdDefault,
     gitCmd: gitCmdInput !== '' ? gitCmdInput : defaults.gitCmdDefault,

--- a/paths.js
+++ b/paths.js
@@ -5,13 +5,13 @@ const defaults = (process.env['OS'] != 'Windows_NT') ? {
     // We use os.userInfo() rather than os.homedir(), since it uses the getpwuid() system call to get the user's home directory (see https://nodejs.org/api/os.html#osuserinfooptions).
     // This mimics the way openssh derives the home directory for locating config files (see https://github.com/openssh/openssh-portable/blob/826483d51a9fee60703298bbf839d9ce37943474/ssh.c#L710);
     // Makes a difference in Docker-based Action runs, when $HOME is different from what getpwuid() returns (which is based on the entry in /etc/passwd)
-    homePath: os.userInfo().homedir,
+    homePathDefault: os.userInfo().homedir,
     sshAgentCmdDefault: 'ssh-agent',
     sshAddCmdDefault: 'ssh-add',
     gitCmdDefault: 'git'
 } : {
     // Assuming GitHub hosted `windows-*` runners for now
-    homePath: os.homedir(),
+    homePathDefault: os.homedir(),
     sshAgentCmdDefault: 'c://progra~1//git//usr//bin//ssh-agent.exe',
     sshAddCmdDefault: 'c://progra~1//git//usr//bin//ssh-add.exe',
     gitCmdDefault: 'c://progra~1//git//bin//git.exe'
@@ -20,9 +20,10 @@ const defaults = (process.env['OS'] != 'Windows_NT') ? {
 const sshAgentCmdInput = core.getInput('ssh-agent-cmd');
 const sshAddCmdInput = core.getInput('ssh-add-cmd');
 const gitCmdInput = core.getInput('git-cmd');
+const homePathInput = core.getInput('home-path');
 
 module.exports = {
-    homePath: defaults.homePath,
+    homePath: homePathInput !== '' ? homePathInput : defaults.homePathDefault,
     sshAgentCmd: sshAgentCmdInput !== '' ? sshAgentCmdInput : defaults.sshAgentCmdDefault,
     sshAddCmd: sshAddCmdInput !== '' ? sshAddCmdInput : defaults.sshAddCmdDefault,
     gitCmd: gitCmdInput !== '' ? gitCmdInput : defaults.gitCmdDefault,


### PR DESCRIPTION
When a GitHub runner is running in Systemd serivce context that is using `DynamicUser=true` setting the `os.userInfo().homedir` call returns `/`(root).

This happens because the Node call uses libuv which calls `getpwuid()` that uses the NSS(Name Service Switch) which provide home path from `/etc/passwd`.

Because of this the action fails with error like this:
```
Error: ENOENT: no such file or directory, mkdir '//.ssh'
```
Allowing users to override it is the simplest fix, for example like this:
```yaml
home-path: $HOME
```